### PR TITLE
Switch IPC::SysV to XSLoader

### DIFF
--- a/lib/IPC/SysV.pm
+++ b/lib/IPC/SysV.pm
@@ -81,14 +81,10 @@ sub AUTOLOAD
 
 BOOT_XS: {
   # If I inherit DynaLoader then I inherit AutoLoader and I DON'T WANT TO
-  require DynaLoader;
+  use XSLoader ();
 
-  # DynaLoader calls dl_load_flags as a static method.
-  *dl_load_flags = DynaLoader->can('dl_load_flags');
+  XSLoader::load( 'IPC::SysV', $VERSION );
 
-  do {
-    __PACKAGE__->can('bootstrap') || \&DynaLoader::bootstrap
-  }->(__PACKAGE__, $VERSION);
 }
 
 1;


### PR DESCRIPTION
p5p has recently switched all CORE modules to XSLoader
for performance reasons during the 5.27 development cycle.

Note, XSLoader is a problem for Perl versions earlier than 5.6,
which at this point can get alternate support, as mentioned
in the upstream case.

Upstream-Case: RT #132080
Upstream-URL: https://rt.perl.org/SelfService/Display.html?id=132080