### PR TITLE
dont require ppport.h to build when inside perl core

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -47,7 +47,8 @@ sub configure
 
   if ($ENV{'PERL_CORE'}) {
     # clean out const-* files in the core
-    push @moreopts, realclean => { FILES => "const-c.inc const-xs.inc" };
+    push @moreopts, realclean => { FILES => "const-c.inc const-xs.inc" },
+                    DEFINE => '-DNO_PPPORT_H';
   }
   else {
     # IPC::SysV is in the core since 5.005

--- a/SysV.xs
+++ b/SysV.xs
@@ -12,9 +12,11 @@
 #include "perl.h"
 #include "XSUB.h"
 
-#define NEED_sv_2pv_flags
-#define NEED_sv_pvn_force_flags
-#include "ppport.h"
+#ifndef NO_PPPORT_H
+#  define NEED_sv_2pv_flags
+#  define NEED_sv_pvn_force_flags
+#  include "ppport.h"
+#endif
 
 #include <sys/types.h>
 


### PR DESCRIPTION
-this allows for this module to be removed from mkppport.lst and eventually
 removal of the mkppport script and more parallelzation building everything
 inside the core p5p makefile