### PR TITLE
Fix compile warnings with -Wsign-compare

### DIFF
--- a/SysV.xs
+++ b/SysV.xs
@@ -379,7 +379,7 @@ memwrite(addr, sv, pos, size)
     char *caddr = (char *) sv2addr(addr);
     STRLEN len;
     const char *src = SvPV_const(sv, len);
-    int n = ((int) len > size) ? size : (int) len;
+    unsigned int n = ((unsigned int) len > size) ? size : (unsigned int) len;
     Copy(src, caddr + pos, n, char);
     if (n < size)
     {


### PR DESCRIPTION
Fix #8

Note: as this is raising some warning in Perl blead since release-2.08 with 7dea23fdfca5d51e3617f273912c3405cd04ef4b
once merged we should perform a new release so we could bump IPC-SysV in blead